### PR TITLE
Cargo features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,6 @@ dependencies = [
  "ahash",
  "poise",
  "rand 0.10.1",
- "serde",
  "serenity",
  "songbird",
  "symphonia 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,28 +3594,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
- "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
- "symphonia-codec-adpcm",
- "symphonia-codec-pcm",
- "symphonia-codec-vorbis",
  "symphonia-core",
- "symphonia-format-mkv",
- "symphonia-format-ogg",
  "symphonia-format-riff",
  "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -3631,37 +3613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "symphonia-codec-adpcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-vorbis"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-utils-xiph",
-]
-
-[[package]]
 name = "symphonia-core"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,31 +3623,6 @@ dependencies = [
  "bytemuck",
  "lazy_static",
  "log",
-]
-
-[[package]]
-name = "symphonia-format-mkv"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-ogg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -3721,16 +3647,6 @@ dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["discord", "audio", "bot", "soundboard", "civ"]
 categories = ["games", "multimedia::audio"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
 rand = "0.10"
 serenity = {version = "0.12", features = ["client", "standard_framework", "voice"] }
 poise = { version = "0.6" }
@@ -20,7 +19,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ahash = { version = "0.8" }
 
 [profile.release]
-lto = true
+lto = "fat"
 codegen-units = 1
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,22 @@ keywords = ["discord", "audio", "bot", "soundboard", "civ"]
 categories = ["games", "multimedia::audio"]
 
 [dependencies]
-rand = "0.10"
-serenity = {version = "0.12", features = ["client", "standard_framework", "voice"] }
-poise = { version = "0.6" }
-songbird = { version = "0.6", features = ["builtin-queue"] }
-# Tried 0.6 on 2026-05-16, no luck. Songbird is probably not yet compatible.
+rand = { version = "0.10", default-features = false, features = ["thread_rng"] }
+# For the serenity-rs stack, mostly just yoinking their default features.
+serenity = {version = "0.12", default-features = false, features = ["default_no_backend", "rustls_backend", "voice"] }
+poise = { version = "0.6", default-features = false, features = ["cache", "chrono", "handle_panics"] }
+# builtin-queue in addition to defaults:
+songbird = { version = "0.6", default-features = false, features = ["driver", "gateway", "rustls", "serenity", "tungstenite", "builtin-queue"] }
+# Tried symphonia 0.6 on 2026-05-16, no luck. Songbird is probably not yet compatible.
 # https://github.com/pdeljanov/Symphonia/blob/main/docs/guides/migration/0p6.md
-symphonia = { version = "0.5", features = ["mp3"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-ahash = { version = "0.8" }
+# Currently just supporting mp3 and wav, could add future feature support to
+# toglle more features.
+symphonia = { version = "0.5", default-features = false, features = ["wav", "mp3"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+ahash = { version = "0.8", default-features = false, features = ["runtime-rng", "std"] }
 
 [features]
-default = ["civ"]
+default = []
 civ = []
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ symphonia = { version = "0.6", features = ["mp3"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ahash = { version = "0.8" }
 
+[features]
+default = ["civ"]
+civ = []
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -225,5 +225,6 @@ For your convenience, simply run `./run.sh`.
 ### Prerequisites
 
 - [Rust toolchain](https://rustup.rs/)
+- `cmake`: `sudo apt update; sudo apt install cmake` (version `3.22.1` tested)
 - (Optional): [just](https://just.systems/man/en/installation.html): `cargo install --locked just`
 - (Optional): [just-lsp](https://github.com/terror/just-lsp): `cargo install --locked just-lsp`

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ lint:
 
 test:
     cargo test --all-features --no-fail-fast
+    cargo test --no-default-features
 
 fix:
     cargo fmt --all

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@
 set -euo pipefail
 DISCORD_TOKEN="$(<token)"
 export DISCORD_TOKEN
-cargo run --release -- "${1:-audio}"
+cargo run --release --all-features -- "${1:-audio}"

--- a/src/civ.rs
+++ b/src/civ.rs
@@ -2,7 +2,6 @@ use ahash::AHashSet;
 use rand::RngExt;
 use rand::rngs::ThreadRng;
 use rand::seq::SliceRandom;
-use serde::Deserialize;
 
 pub const GAME_MODES: [&str; 8] = [
     "Apocalypse",
@@ -176,11 +175,9 @@ Sea Level:              {sea_level}
     )
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Leader {
-    #[serde(rename = "Leader")]
     pub name: String,
-    #[serde(rename = "Civilization")]
     pub civ: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,16 +587,23 @@ async fn main() {
     keys.sort();
     command.aliases = data.file_map.keys().cloned().collect();
 
-    let mut commands = vec![list(), random(), disconnect(), dice(), help(), command];
+    #[cfg(not(feature = "civ"))]
+    let commands = vec![list(), random(), disconnect(), dice(), help(), command];
 
     #[cfg(feature = "civ")]
-    commands.extend(vec![
+    let commands = vec![
+        list(),
+        random(),
+        disconnect(),
+        dice(),
+        help(),
         civ_draft(),
         civ_list_modes(),
         civ_draw_modes(),
         civ_draw_map(),
         civ_draw_settings(),
-    ]);
+        command,
+    ];
 
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "civ")]
 mod civ;
+#[cfg(feature = "civ")]
 use crate::civ::{GAME_MODES, draw_leaders, draw_map, draw_modes, draw_settings};
 use ahash::AHashMap;
 use poise::serenity_prelude as serenity;
@@ -331,6 +333,7 @@ async fn random(ctx: Context<'_>, cat: Option<String>) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "civ")]
 #[allow(clippy::doc_markdown)]
 /// Draw random leaders: "!civ_draft n_players n_leaders."
 ///
@@ -364,6 +367,7 @@ async fn civ_draft(ctx: Context<'_>, n_players: usize, n_leaders: usize) -> Resu
     Ok(())
 }
 
+#[cfg(feature = "civ")]
 #[allow(clippy::doc_markdown)]
 /// List game modes. Useful in conjunction with "!civ_draw_modes"
 #[poise::command(prefix_command)]
@@ -377,6 +381,7 @@ async fn civ_list_modes(ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "civ")]
 #[allow(clippy::doc_markdown)]
 /// Draw random game modes. See also "!civ_list_modes"
 ///
@@ -446,6 +451,7 @@ async fn civ_draw_modes(
     Ok(())
 }
 
+#[cfg(feature = "civ")]
 /// Draw a single random map.
 #[poise::command(prefix_command)]
 async fn civ_draw_map(ctx: Context<'_>) -> Result<(), Error> {
@@ -454,6 +460,7 @@ async fn civ_draw_map(ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(feature = "civ")]
 /// Draw random game settings to jump-start Civilization VI game setup.
 #[poise::command(prefix_command)]
 async fn civ_draw_settings(ctx: Context<'_>) -> Result<(), Error> {
@@ -580,22 +587,21 @@ async fn main() {
     keys.sort();
     command.aliases = data.file_map.keys().cloned().collect();
 
+    let mut commands = vec![list(), random(), disconnect(), dice(), help(), command];
+
+    #[cfg(feature = "civ")]
+    commands.extend(vec![
+        civ_draft(),
+        civ_list_modes(),
+        civ_draw_modes(),
+        civ_draw_map(),
+        civ_draw_settings(),
+    ]);
+
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             prefix_options: prefix_framework_options,
-            commands: vec![
-                list(),
-                random(),
-                disconnect(),
-                dice(),
-                civ_draft(),
-                civ_list_modes(),
-                civ_draw_modes(),
-                civ_draw_map(),
-                civ_draw_settings(),
-                help(),
-                command,
-            ],
+            commands,
             ..Default::default()
         })
         .setup(|ctx, _ready, framework| {


### PR DESCRIPTION
- Drop explicit `serde` dep (missed this on the `csv` removal PR)
- Explicitly specify features for all deps
- Introduce `civ` feature for project that's off by default (still on via `run.sh`)