### PR TITLE
Cross compilation + .deb installs (systemd unit)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "disquip-bot-rs"
+name = "disquip-bot"
 version = "0.7.1"
 dependencies = [
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "disquip-bot-rs"
+name = "disquip-bot"
 version = "0.7.1"
 edition = "2024"
 description = "A Discord bot to play audio files (quips) on command"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,28 @@ name = "disquip-bot"
 version = "0.7.1"
 edition = "2024"
 description = "A Discord bot to play audio files (quips) on command"
+documentation = "https://github.com/blthayer/disquip-bot-rs/blob/main/README.md"
 readme = "README.md"
 repository = "https://github.com/blthayer/disquip-bot-rs"
+homepage = "https://github.com/blthayer/disquip-bot-rs"
 license = "MIT"
 keywords = ["discord", "audio", "bot", "soundboard", "civ"]
 categories = ["games", "multimedia::audio"]
+
+[package.metadata.deb]
+maintainer = "Brandon Thayer <bthayer@tuta.com>"
+copyright = "2025, Brandon Thayer <bthayer@tuta.com>"
+license-file = ["LICENSE", "4"]
+extended-description = """\
+A Discord bot to play audio files (quips) on command.
+Users enter commands into a Discord text channel in a server in which the bot has been added/registered.
+Additionally includes randomization features for Civilization VI game setup.
+"""
+depends = "$auto"
+section = "sound"
+priority = "optional"
+maintainer-scripts = "systemd/"
+systemd-units = [{ unit-name = "disquip-bot", enable = true, start = true }]
 
 [dependencies]
 rand = { version = "0.10", default-features = false, features = ["thread_rng"] }

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ to the file containing your Discord token. Example:
 
 ### Pre-built Binaries
 
+TODO/WIP: pre-built binaries on GitHub not yet available.
+
 A limited set of pre-built binaries are provided for each
 [release](https://github.com/blthayer/disquip-bot-rs/releases).
 
@@ -259,7 +261,9 @@ TODO
 
 If you'd like to install `disquip-bot` with `apt` and run as a daemon (service)
 managed by `systemd` with automatic program (re)start, follow the directions here.
+This is especially useful if you have an always-on server like a Raspberry Pi.
 
+TODO/WIP: pre-built debs on GitHub not yet available.
 A limited set of pre-built `.deb` packages are provided for each
 [release](https://github.com/blthayer/disquip-bot-rs/releases). Download the `.deb`
 approporate for your target machine.
@@ -359,9 +363,9 @@ sudo apt remove --purge disquip-bot
 sudo rm -r /etc/disquip-bot/token
 ```
 
-Additionally, consider deleting the audio files/directory.
+Additionally, consider deleting the audio files/directory at `/usr/share/disquip-bot`
 
-#### Unpgrading
+#### Upgrading
 
 Simply install a newer `.deb` via `apt`.
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@ DisQuip Bot: Discord bot that plays audio clips from local files into voice chan
 on command.
 
 In essence, this is a customizable soundboard. Commands for randomizing aspects of
-Civilization VI game setup are also included (assumes you have all the DLC). This
-program is implemented in Rust.
-
-**This is a self-hosted bot** - *you* perform Discord configuration, collect your
-own audio files, and run this program on your own PC, server, Raspberry Pi, etc.
+Civilization VI game setup are optionally included (assumes you have all the DLC).
 
 This is a re-implementation of the now defunct
 [disquip-bot](https://github.com/blthayer/disquip-bot), originally written in
 Python. Unfortunately the original DisQuip bot died an early death due to Discord
 updating their API in a backwards-incompatible way.
+
+## Disclaimers
+
+**This is a self-hosted bot** - *you* perform Discord configuration, collect your
+own audio files, and run this program on your own PC, server, Raspberry Pi, etc.
+
+**This is (working) beta software** - while this program works swimmingly for my
+personal use and I'd love it if you gave it a try as well, it is not guaranteed
+to work everywhere, be 100% secure, be 100% stable, or be 100% "productionized."
 
 ## Quick Start
 
@@ -23,7 +28,7 @@ updating their API in a backwards-incompatible way.
    in this directory.
 1. Create subdirectories in the `audio` directory and populate them with `mp3`
    and/or `wav` files.
-1. Compile and run: `./run.sh`
+1. Compile and run locally: `./run.sh`
 
 ## Disclaimer
 
@@ -36,14 +41,15 @@ this freely available software.
 
 If you encounter any issues, please do file an issue or submit a pull request.
 
-## Usage
+## Usage Within Discord
 
-TL;DR: Type `!help` into a text channel and go from there!
+TL;DR: Type `!help` into a Discord server's text channel that the bot is authorized
+to read from and write to, and go from there!
 
 This section covers interacting with the bot/app through Discord, and assumes the
 app is properly configured and the program is running. See [Quick Start](#quick-start)
 or [Setup, Install, and Run](#setup-install-and-run) sections of this document for
-more information on getting the bot running.
+more information on getting the bot running (launching the program).
 
 All commands for the bot are prefixed with `!` and are entered into a text channel
 that the bot is able to read and respond to messages in. In order to play audio
@@ -61,14 +67,16 @@ the following:
 
 ```
 Commands:
-  !list             List quip categories or list quips for a given command. E.g., "!list" or "!list a1"
-  !random           Aka "!r" or "!rand." Play a random quip.
-  !disconnect       Disconnect the bot from its current voice channel.
-  !civ_draft        Draw random leaders: "!civ_draft n_players n_leaders."
-  !civ_list_modes   List game modes. Useful in conjunction with "!civ_draw_modes"
-  !civ_draw_modes   Draw random game modes. See also "!civ_list_modes"
-  !civ_draw_map     Draw a single random map.
-  !help             Show help menu.
+  !list                List quip categories or list quips for a given command. E.g., "!list" or "!list a1"
+  !random              Aka "!r" or "!rand." Play a random quip.
+  !disconnect          Disconnect the bot from its current voice channel.
+  !dice                Roll the dice! Aka "!d." Usage: "!dice <n sides> <n dice>" - n dice defaults to 1
+  !help                Show help menu.
+  !civ_draft           Draw random leaders: "!civ_draft n_players n_leaders."
+  !civ_list_modes      List game modes. Useful in conjunction with "!civ_draw_modes"
+  !civ_draw_modes      Draw random game modes. See also "!civ_list_modes"
+  !civ_draw_map        Draw a single random map.
+  !civ_draw_settings   Draw random game settings to jump-start Civilization VI game setup.
 
 Type "!<category> <number>" (e.g., "a1 1") to play a quip!
 Type "!list" to discover available quip categories.
@@ -108,7 +116,7 @@ sw
 ```
 
 For inspiration, my personal setup here includes the taunts from the Age of Empires
-games in the a1-a3 categories, clips from the Halo games in `halo`, Lord of the Rings
+games in the `a1`-`a3` categories, clips from the Halo games in `halo`, Lord of the Rings
 movie audio clips in `lotr`, miscellaneous quips in `misc`, and of course clips from
 Star Wars in `sw`.
 
@@ -128,7 +136,7 @@ To play the taunt that says "No," you would then type `!a3 2` into the text chan
 
 #### Playing a quip
 
-TL;DR example: `!a3 2`
+TL;DR: `!a3 2`
 
 See [list](#list) first.
 
@@ -150,19 +158,12 @@ available to the bot.
 This program is known to work on the following Linux systems:
 
 - Pop!_OS 22.04 LTS, x86_64 architecture
-- Debian 11 (bullseye), aarch64 architecture (Raspberry Pi 4 Model B Rev 1.5)
+- TODO, WIP: Raspberry Pi OS (Debian 13, a.k.a. "Trixie"), aarch64 architecture (Raspberry Pi 4 Model B Rev 1.5)
+- JetPack 6 (aka Ubuntu 22), aarch64 architecture (NVIDIA Jetson, Orin Nano)
 
 It very likely functions on other operating systems, but has not been tested on
 any besides those listed here. Please submit a PR to add your setup and any
 additional directions required.
-
-### Prerequisites
-
-- [Rust toolchain](https://rustup.rs/). Tested with `rustc` versions `1.92.0`
-  and `1.93.1`.
-- `cmake`: Simply `sudo apt update; sudo apt install cmake` on a Debian-based
-  Linux system (*e.g.*, Debian, Ubuntu, Pop!_OS, Mint, *etc.*). Tested with
-  version `3.22.1`.
 
 ### Discord App Configuration
 
@@ -216,9 +217,153 @@ Tips:
   volume range is similar. The previous Python version of the bot leveraged
   [ffmpeg-normalize](https://github.com/slhck/ffmpeg-normalize) for this purpose.
 
-### Run
+### Prerequisites (Building From Source)
 
-For your convenience, simply run `./run.sh`.
+To build from source, the following tools are required:
+
+- [Rust toolchain](https://rustup.rs/). Tested with the latest version
+  (`rustc` version `1.95.0`), should work on older (but recent) versions as well.
+- `gcc`: Easiest path is to `sudo apt update; sudo apt install build-essential`
+- `cmake`: Simply `sudo apt update; sudo apt install cmake` on a Debian-based
+  Linux system (*e.g.*, Debian, Ubuntu, Pop!_OS, Mint, *etc.*). Tested with
+  version `3.22.1`.
+
+### Build from Source, Run Locally
+
+For your convenience, simply run `./run.sh`. The script (and the program)
+take two positional arguments: The path to your audio files and the path
+to the file containing your Discord token. Example:
+
+```bash
+./run.sh audio token
+```
+
+### Pre-built Binaries
+
+A limited set of pre-built binaries are provided for each
+[release](https://github.com/blthayer/disquip-bot-rs/releases).
+
+Run the binary with no arguments or `--help` to get help. Example:
+
+Example:
+
+```bash
+./disquip-bot audio token
+```
+
+### crates.io
+
+TODO
+
+### `apt` / `systemd`
+
+If you'd like to install `disquip-bot` with `apt` and run as a daemon (service)
+managed by `systemd` with automatic program (re)start, follow the directions here.
+
+A limited set of pre-built `.deb` packages are provided for each
+[release](https://github.com/blthayer/disquip-bot-rs/releases). Download the `.deb`
+approporate for your target machine.
+
+If there is not an appropriate `.deb` for your OS/architecture, it's relatively easy
+to create one for yourself. See the [Development](#development) section for
+prerequisites to build from source. There are several `deb*` recipes in the `justfile`
+- choose the one that best matches your use case. For building directly on the target,
+use the plain `deb` recipe, *e.g.* `just deb`.
+
+Prior to installation, we need to set up the Discord token and audio files. For the
+token:
+
+```bash
+sudo mkdir /etc/disquip-bot
+sudo touch /etc/disquip-bot/token
+sudo chmod 600 /etc/disquip-bot/token
+# Use your favorite editor to put the token in the file.
+# Avoid printing the token to the shell console so it doesn't
+# wind up in shell history.
+sudo nano /etc/disquip-bot/token
+```
+
+The program will look for audio files in `/usr/share/disquip-bot/audio`. You can
+directly place the audio file tree here (recommended), or use a symbolic link.
+Direct placement:
+
+```bash
+sudo mkdir -p /usr/share/disquip-bot/audio
+sudo cp -r /path/to/my/audio/* /usr/share/disquip-bot/audio/
+```
+
+Alternatively, using a symbolic link:
+
+```bash
+sudo mkdir /usr/share/disquip-bot
+sudo ln -s /path/to/my/audio /usr/share/disquip-bot/audio
+```
+
+NOTE: permissions can be tricky with the symbolic link approach. The service is run
+as a dynamic, unpriveleged user. This user must be able to read and execute (to list
+files) in the audio directory, which will not work in your user's home directory,
+except maybe in `~/Public`.
+
+Finally, we're ready to install the program, which is as simple as:
+
+```bash
+sudo apt install ./name-of-deb.deb
+```
+
+where `name-of-deb.deb` is appropriately replaced with the file you either downloaded
+or built locally.
+
+#### Working with the Service
+
+Check service health:
+
+```bash
+sudo systemctl status disquip-bot
+```
+
+Inspect the logs:
+
+```bash
+sudo journalctl -u disquip-bot
+```
+
+Prevent the service from running on boot:
+
+```bash
+sudo systemctl disable disquip-bot
+```
+
+Manually start the service:
+
+```bash
+sudo systemctl start disquip-bot
+```
+
+Manually stop the service:
+
+```bash
+sudo systemctl stop disquip-bot
+```
+
+Manually restart the service:
+
+```bash
+sudo systemctl restart disquip-bot
+```
+
+#### Uninstalling
+
+```bash
+sudo systemctl stop disquip-bot
+sudo apt remove --purge disquip-bot
+sudo rm -r /etc/disquip-bot/token
+```
+
+Additionally, consider deleting the audio files/directory.
+
+#### Unpgrading
+
+Simply install a newer `.deb` via `apt`.
 
 ## Development
 
@@ -226,14 +371,17 @@ For your convenience, simply run `./run.sh`.
 
 - [Rust toolchain](https://rustup.rs/)
 - `cmake`: `sudo apt update; sudo apt install cmake` (version `3.22.1` tested)
-- (Optional): [just](https://just.systems/man/en/installation.html): `cargo install --locked just`
-- (Optional): [just-lsp](https://github.com/terror/just-lsp): `cargo install --locked just-lsp`
+- (Optional) [just](https://just.systems/man/en/installation.html): `cargo install --locked just`
+- (Optional) [just-lsp](https://github.com/terror/just-lsp): `cargo install --locked just-lsp`
+- (Optional) [cargo-deb](https://docs.rs/crate/cargo-deb/latest): `cargo install --locked cargo-deb`
 
 If you choose not to install and use `just`, you can manually copy + run recipes from
 the `justfile`, which will be referenced throughout.
 
 ### Cross-compiling (`aarch64-unknown-linux-gnu`)
 
+Cross-compiling can be a bit of a headache. If possible, consider building directly
+on your target instead.
 
 ```console
 # One time installs:
@@ -242,6 +390,6 @@ sudo apt install -y gcc-aarch64-linux-gnu
 rustup target add aarch64-unknown-linux-gnu
 
 # Build:
-just build-rpi4b
-# or just build-jetson
+just build-aarch64
+# See also build-rpi4bi and build-jetson
 ```

--- a/README.md
+++ b/README.md
@@ -228,3 +228,20 @@ For your convenience, simply run `./run.sh`.
 - `cmake`: `sudo apt update; sudo apt install cmake` (version `3.22.1` tested)
 - (Optional): [just](https://just.systems/man/en/installation.html): `cargo install --locked just`
 - (Optional): [just-lsp](https://github.com/terror/just-lsp): `cargo install --locked just-lsp`
+
+If you choose not to install and use `just`, you can manually copy + run recipes from
+the `justfile`, which will be referenced throughout.
+
+### Cross-compiling (`aarch64-unknown-linux-gnu`)
+
+
+```console
+# One time installs:
+sudo apt update
+sudo apt install -y gcc-aarch64-linux-gnu
+rustup target add aarch64-unknown-linux-gnu
+
+# Build:
+just build-rpi4b
+# or just build-jetson
+```

--- a/justfile
+++ b/justfile
@@ -9,5 +9,20 @@ fix:
     cargo fmt --all
     cargo clippy --all-features --fix --allow-dirty
 
+build:
+    RUSTFLAGS="-C target-cpu=native" cargo build --all-features --release
+
+# For a generic aarch64 target, just remove the target-cpu.
+# Tested on a Raspberry Pi Model 4B running TODO.
+# For other RPi models, verify cpu with lscpu.
+# TODO: Not working yet.
+build-rpi4b:
+    RUSTFLAGS="-C target-cpu=cortex-a72 -C target-feature=+crt-static,+neon" cargo build --all-features --release --target=aarch64-unknown-linux-gnu
+
+# NVIDIA Jetson. I believe all Jetsons have the same CPU, but verify
+# via lscpu prior to building. Tested on Orin Nano.
+build-jetson:
+    RUSTFLAGS="-C target-cpu=cortex-a78ae -C target-feature=+crt-static,+neon" cargo build --all-features --release --target=aarch64-unknown-linux-gnu
+
 # Everything you should do before opening a pull request.
 pr: fix lint test

--- a/justfile
+++ b/justfile
@@ -12,6 +12,11 @@ fix:
 build:
     RUSTFLAGS="-C target-cpu=native" cargo build --all-features --release
 
+# Generic aarch64 target, no specific CPU. Assuming Neon support, as apparently
+# most ARM CPUs support Neon instructions.
+build-aarch64:
+    RUSTFLAGS="-C target-feature=+crt-static,+neon" cargo build --all-features --release --target=aarch64-unknown-linux-gnu
+
 # For a generic aarch64 target, just remove the target-cpu.
 # Tested on a Raspberry Pi Model 4B running TODO.
 # For other RPi models, verify cpu with lscpu.
@@ -24,5 +29,20 @@ build-rpi4b:
 build-jetson:
     RUSTFLAGS="-C target-cpu=cortex-a78ae -C target-feature=+crt-static,+neon" cargo build --all-features --release --target=aarch64-unknown-linux-gnu
 
+deb: build
+    cargo deb --all-features --no-build
+
+_deb-aarch64:
+    cargo deb --target=aarch64-unknown-linux-gnu --no-build 
+
+deb-aarch64: build-aarch64 _deb-aarch64
+
+deb-rpi4b: build-rpi4b _deb-aarch64
+
+deb-jetson: build-jetson _deb-aarch64
+
 # Everything you should do before opening a pull request.
 pr: fix lint test
+
+release:
+    echo "TODO: tag, build, upload"

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
-# One argument: path to audio files directory (default: "audio").
-
 set -euo pipefail
-DISCORD_TOKEN="$(<token)"
-export DISCORD_TOKEN
-cargo run --release --all-features -- "${1:-audio}"
+RUSTFLAGS="-C target-cpu=native" cargo run --release --all-features -- "${1:-audio}" "${2:-token}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,22 +27,34 @@ struct Data {
     pub map_len: usize,
 }
 
+// TODO: Could use nicer error proliferation with anyhow instead of
+// std::process:: sprinklings.
+fn read_dir_or_exit(dir: &str) -> std::fs::ReadDir {
+    match read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            eprintln!("Failed to read directory at {dir}: {e:?}");
+            std::process::exit(1);
+        }
+    }
+}
+
 impl Data {
-    fn new(top_dir: String) -> Data {
+    fn new(top_dir: &str) -> Data {
         // Initialize the file map and a counter for the total number of DirEntries.
         let mut file_map: AHashMap<String, Vec<DirEntry>> = AHashMap::new();
         let mut map_len: usize = 0;
 
         // Loop over directories within the top_dir and fill out the AHashMap.
-        let result = read_dir(top_dir).unwrap();
-        for r in result {
+        let rd = read_dir_or_exit(top_dir);
+        for r in rd {
             let u = r.unwrap();
             // Only work with directories.
             if u.file_type().unwrap().is_dir() {
                 // Iterate over the files and place in the AHashMap using the
                 // directory's name as a key.
                 let key = u.file_name().into_string().unwrap();
-                let files = read_dir(u.path()).unwrap();
+                let files = read_dir_or_exit(u.path().to_str().unwrap());
                 for f in files {
                     let dir_entry = f.unwrap();
                     match file_map.entry(key.clone()) {
@@ -521,17 +533,14 @@ fn tickify(text: &str) -> String {
 // Exits the process.
 fn usage() -> ! {
     println!(
-        "
-Usage: disquip-bot-rs [-h | --help] /path/to/audio/files
+"
+Usage: disquip-bot-rs [-h | --help] /path/to/audio/files /path/to/token
 
-E.g.: \"disquip-bot-rs audio\" for an audio file tree in the local directory \"audio\"
+E.g.: \"disquip-bot-rs audio token\" for an \"audio\" directory and \"token\" file in the current directory.
 
-*** The \"DISCORD_TOKEN\" environment variable must be set. ***
+It is recommended that the token file use 600 permissions for security. Avoid leaking credentials to shell history when creating the file.
 
-For security, it's recommended to avoid leaking tokens to shell history. This can be
-achieved by modifying your shell history settings, or storing the token in a properly
-permissioned file (e.g., 600) and using a helper script to launch the program. You
-can find an example at https://github.com/blthayer/disquip-bot-rs/blob/main/run.sh.
+Currently, \"mp3\" and \"wav\" audio files are supported. Additional formats can be enabled at compile-time by adding features to the \"symphonia\" dependency in the project's \"Cargo.toml\" file. This requires building from source. 
 "
     );
     std::process::exit(1);
@@ -547,30 +556,35 @@ fn parse_args() -> (String, String) {
         usage();
     }
 
-    let top_dir = match args.len().cmp(&2) {
-        std::cmp::Ordering::Less => {
-            println!("Received zero arguments.");
+    let n: usize = 3;
+    let (top_dir, token_path) = match args.len().cmp(&n) {
+        std::cmp::Ordering::Less | std::cmp::Ordering::Greater => {
+            eprintln!("Received {} arguments, expected {n}\n", args.len() - 1);
             usage();
         }
-        std::cmp::Ordering::Equal => std::mem::take(&mut args[1]),
-        std::cmp::Ordering::Greater => {
-            println!("Received {} arguments.\n", args.len() - 1);
-            usage();
-        }
+        std::cmp::Ordering::Equal => (std::mem::take(&mut args[1]), std::mem::take(&mut args[2])),
     };
 
-    let Ok(token) = std::env::var("DISCORD_TOKEN") else {
-        println!("The \"DISCORD_TOKEN\" environment variable was not set.");
-        usage();
-    };
-
-    (top_dir, token)
+    (top_dir, token_path)
 }
 
 #[tokio::main]
 async fn main() {
-    let (top_dir, token) = parse_args();
-    let data = Data::new(top_dir);
+    // Collect arguments
+    let (top_dir, token_path) = parse_args();
+
+    // Read the token from file.
+    let token = match std::fs::read_to_string(&token_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error reading token file at {token_path}: {e:?}");
+            std::process::exit(1);
+        }
+    };
+    println!("Discord token successfully read from {token_path}.");
+
+    let data = Data::new(&top_dir);
+    println!("One time mapping of audio directory {top_dir} completed.");
 
     let intents = serenity::GatewayIntents::non_privileged()
         | serenity::GatewayIntents::GUILD_MESSAGES
@@ -619,9 +633,20 @@ async fn main() {
         })
         .build();
 
-    let client = serenity::ClientBuilder::new(token, intents)
+    let mut client = match serenity::ClientBuilder::new(token.trim(), intents)
         .framework(framework)
         .register_songbird()
-        .await;
-    client.unwrap().start().await.unwrap();
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error starting serenity client: {e:?}");
+            std::process::exit(1);
+        }
+    };
+    println!("Serenity client initialized, about to start it and run forever...");
+    if let Err(e) = client.start().await {
+        eprintln!("The serenity client has failed: {e:?}");
+        std::process::exit(1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,8 +533,7 @@ fn tickify(text: &str) -> String {
 // Exits the process.
 fn usage() -> ! {
     println!(
-"
-Usage: disquip-bot-rs [-h | --help] /path/to/audio/files /path/to/token
+"Usage: disquip-bot-rs [-h | --help] /path/to/audio/files /path/to/token
 
 E.g.: \"disquip-bot-rs audio token\" for an \"audio\" directory and \"token\" file in the current directory.
 
@@ -559,7 +558,11 @@ fn parse_args() -> (String, String) {
     let n: usize = 3;
     let (top_dir, token_path) = match args.len().cmp(&n) {
         std::cmp::Ordering::Less | std::cmp::Ordering::Greater => {
-            eprintln!("Received {} arguments, expected {n}\n", args.len() - 1);
+            eprintln!(
+                "Received {} arguments, expected {}\n",
+                args.len() - 1,
+                n - 1
+            );
             usage();
         }
         std::cmp::Ordering::Equal => (std::mem::take(&mut args[1]), std::mem::take(&mut args[2])),

--- a/systemd/disquip-bot.service
+++ b/systemd/disquip-bot.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=A Discord bot to play audio files (quips) on command
+Documentation=https://github.com/blthayer/disquip-bot-rs/blob/main/README.md
+After=network.target
+
+[Service]
+Type=exec
+# There's absolutely no reason to run as root. Using DynamicUser
+# is probably the most bang for your buck of any systemd option
+# from a security perspective.
+User=disquip-bot
+Group=disquip-bot
+DynamicUser=yes
+# This program need not write anything to the file system.
+ProtectSystem=strict
+# I would make this simply "true" instead of "read-only,"
+# but users may want to keep their audio files in their
+# home directories.
+ProtectHome=read-only
+# TODO: Continue restricting capabilities.
+
+# It is the user's responsibility to set up /usr/share/disquip-bot/audio
+# and /etc/disquip-bot/token. token should use 600 permissions.
+# We'll force appropriate ownership and permissions for the token here.
+# TODO: systemd has credential loading capabilities, but for now, keep
+# it simple and use a properly permissioned file that the program reads.
+ExecStartPre=+/usr/bin/chmod 600 /etc/disquip-bot/token
+ExecStartPre=+/usr/bin/chown disquip-bot:disquip-bot /etc/disquip-bot/token
+# Shouldn't need to mess with permissions for /usr/share/disquip-bot/audio,
+# since if a user created this it should be world-readable by default.
+ExecStart=/usr/bin/disquip-bot /usr/share/disquip-bot/audio /etc/disquip-bot/token
+Restart=always
+# Prevent log spam and CPU spinning with exponential backoff for restarts.
+# RestartSteps and RestartMaxDelaySec were introduced in systemd version 254,
+# so may not be available on older systems. This is okay. systemd will emit
+# a warning.
+RestartSec=15
+RestartSteps=4
+RestartMaxDelaySec=180
+StandardOutput=journal
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Read `token` file (**new** second, mandatory argument to program) instead of using an environment variable
- Set up cross-compilation for aarch64
- Use `cargo deb` to build `.deb` packages with a `systemd` service
- README updates, including some TODO/WIP stubs