### PR TITLE
Move docs into lib.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ For now, this CHANGELOG is hand-curated, so only versions starting at `0.9.0`
 are documented here. Until a `1.0.0` release is published, minor patch bumps
 may include breaking or backwards-incompatible changes.
 
+## `0.9.4`
+
+Move documentation from `src/main.rs` to `src/lib.rs` so doc builds will work
+for docs.rs. `lib.rs` is used **only** for documentation, this remains a binary-only
+project.
+
 ## `0.9.3`
 
 Fix keywords for publishing to crates.io.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "disquip-bot"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "ahash",
  "poise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "disquip-bot"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "A Discord bot to play audio files (quips) on command"
 documentation = "https://github.com/blthayer/disquip-bot-rs/blob/main/README.md"
@@ -61,3 +61,6 @@ codegen-units = 1
 # correctness, suspicious, style, complexity, perf
 all = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
+# prevent clippy from putting backticks in the
+# README...
+doc_markdown = { level = "allow" }

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ lint:
     cargo clippy --all-features -- -D warnings
 
 test:
-    cargo test --all-features --no-fail-fast
-    cargo test --no-default-features
+    cargo test --bins --all-features --no-fail-fast
+    cargo test --bins --no-default-features
 
 fix:
     cargo fmt --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+//! TL;DR:
+//!
+//! ```
+//! cargo install --locked disquip-bot
+//! disquip-bot /path/to/audio/dir /path/to/token/file
+//! ```
+//!
+//! Alternatively, a limited set pre-built binaries (including `.deb` packages)
+//! are available [on GitHub](https://github.com/blthayer/disquip-bot-rs/releases).
+//!
+//! This is a binary-only crate. `lib.rs` exists purely to support documentation
+//! on docs.rs
+//!
+#![doc = include_str!("../README.md")]
+#![doc = include_str!("../CHANGELOG.md")]
+//!
+//! # Feature flags
+//! ## civ
+//! Enables game setup and randomization commands for Civilization VI. Installed
+//! by default in pre-built binaries (see GitHub releases) excluded by default when built from source via
+//! `cargo`.


### PR DESCRIPTION
This way the `rustdoc` build for docs.rs should hopefully succeed :crossed_fingers: 